### PR TITLE
Add `no-use-outside` rule to disallow using private props outside of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,18 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
   "rules": {
-    "private-props/all": 2
+    "private-props/no-unused-or-undeclared": 2
   }
 }
 ```
 
 ## Supported Rules
 
-### `private-props/all`
-Enable support for ES6 classes, React.createClass, and prototypical inheritance
+### `private-props/no-unused-or-undeclared`
+Disallow unused or undeclared private properties
+
+### `private-props/no-use-outside`
+Disallow use of private properties outside of own object
 
 #### Options
 `privateMatchers` Change the default set of matchers for private properties
@@ -54,7 +57,7 @@ Default:
 ```json
 {
   "rules": {
-    "private-props/all": [2, {
+    "private-props/no-unused-or-undeclared": [2, {
       "privateMatchers": [
         "^_", 
         "^handle[A-Z]"

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -2,7 +2,8 @@ var _ = require('lodash');
 
 const MESSAGES = {
   UNDECLARED: "'%s' is undeclared",
-  UNUSED: "'%s' is never used"
+  UNUSED: "'%s' is never used",
+  NO_USE: "'%s' used outside of object"
 };
 
 module.exports = _.extend(_.mapValues((MESSAGES), (val, key) => key), {

--- a/lib/private-matcher.js
+++ b/lib/private-matcher.js
@@ -1,0 +1,19 @@
+var _ = require('lodash');
+
+const defaultPrivateMatchers = ['^_', '^handle[A-Z]'];
+
+function compileRegExpStrings(regExpStrings) {
+  return _.map(regExpStrings, (str) => new RegExp(str));
+}
+
+var PrivateMatcher = function(privateMatchers) {
+  this.privateMatchers = compileRegExpStrings(privateMatchers || defaultPrivateMatchers);
+};
+
+PrivateMatcher.prototype = {
+  isPrivateProperty: function(name) {
+    return _.some(this.privateMatchers, (prefix) => prefix.test(name));
+  }
+};
+
+module.exports = PrivateMatcher;

--- a/lib/privates.js
+++ b/lib/privates.js
@@ -1,19 +1,12 @@
 /* Processes AST nodes for private method/property declarations and usages */
-var _ = require('lodash');
-var Messages = require('./messages');
-
-const defaultPrivateMatchers = ['^_', '^handle[A-Z]'];
-
-function compileRegExpStrings(regExpStrings) {
-  return _.map(regExpStrings, (str) => new RegExp(str));
-}
+var _              = require('lodash');
+var Messages       = require('./messages');
+var PrivateMatcher = require('./private-matcher');
 
 var Privates = function(opts) {
   opts = opts || {};
 
-  this.privateMatchers = compileRegExpStrings(
-    opts.privateMatchers || defaultPrivateMatchers
-  );
+  this.privateMatcher = new PrivateMatcher(opts.privateMatchers);
 
   this.isProcessing = false;
 };
@@ -134,7 +127,7 @@ Privates.prototype = {
   },
 
   _isPrivateProperty: function(name) {
-    return _.some(this.privateMatchers, (prefix) => prefix.test(name));
+    return this.privateMatcher.isPrivateProperty(name);
   }
 };
 

--- a/lib/rules/no-unused-or-undeclared.js
+++ b/lib/rules/no-unused-or-undeclared.js
@@ -25,7 +25,7 @@ function isPrototype(expression) {
 module.exports = {
   meta: {
     docs: {
-      description: 'disallow unused and undeclared private methods and properties',
+      description: 'disallow unused or undeclared private properties',
       category: 'Possible Errors',
       recommended: true
     },

--- a/lib/rules/no-use-outside.js
+++ b/lib/rules/no-use-outside.js
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Rule to disallow accessing private properties outside of defined object
+ * @author Warren Ouyang
+ */
+
+'use strict';
+
+var Messages       = require('../messages');
+var PrivateMatcher = require('../private-matcher');
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'disallow use of private properties outside of own object',
+      category: 'Possible Errors',
+      recommended: true
+    },
+    schema: [{
+      'type': 'object',
+      'properties': {
+        'privateMatchers': {
+          'type': 'array',
+          'items': {'type': 'string'}
+        }
+      },
+      'additionalProperties': false
+    }]
+  },
+
+  create: function(context) {
+    var config = context.options[0] || {};
+
+    var privateMatcher = new PrivateMatcher(config.privateMatchers);
+
+    return {
+      MemberExpression(expression) {
+        var name = expression.property.name;
+        if (privateMatcher.isPrivateProperty(name) && expression.object.type !== 'ThisExpression') {
+          context.report(expression.property, Messages.get(Messages.NO_USE, name));
+        }
+      }
+    };
+  }
+};

--- a/test/lib/rules/no-unused-or-undeclared.for-class.js
+++ b/test/lib/rules/no-unused-or-undeclared.for-class.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var rule = require('../../../lib/rules/all');
+var rule = require('../../../lib/rules/no-unused-or-undeclared');
 var Messages = require('../../../lib/messages');
 var RuleTester = require('eslint').RuleTester;
 
@@ -16,7 +16,7 @@ RuleTester.setDefaultConfig({
 
 
 var ruleTester = new RuleTester();
-ruleTester.run('all', rule, {
+ruleTester.run('no-unused-or-undeclared', rule, {
 
   valid: [
     `

--- a/test/lib/rules/no-unused-or-undeclared.for-prototype.js
+++ b/test/lib/rules/no-unused-or-undeclared.for-prototype.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var rule = require('../../../lib/rules/all');
+var rule = require('../../../lib/rules/no-unused-or-undeclared');
 var Messages = require('../../../lib/messages');
 var RuleTester = require('eslint').RuleTester;
 
@@ -16,7 +16,7 @@ RuleTester.setDefaultConfig({
 
 
 var ruleTester = new RuleTester();
-ruleTester.run('all', rule, {
+ruleTester.run('no-unused-or-undeclared', rule, {
 
   valid: [
     `

--- a/test/lib/rules/no-unused-or-undeclared.for-react-create-class.js
+++ b/test/lib/rules/no-unused-or-undeclared.for-react-create-class.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var rule = require('../../../lib/rules/all');
+var rule = require('../../../lib/rules/no-unused-or-undeclared');
 var Messages = require('../../../lib/messages');
 var RuleTester = require('eslint').RuleTester;
 
@@ -16,7 +16,7 @@ RuleTester.setDefaultConfig({
 
 
 var ruleTester = new RuleTester();
-ruleTester.run('all', rule, {
+ruleTester.run('no-unused-or-undeclared', rule, {
 
   valid: [
     `

--- a/test/lib/rules/no-use-outside.js
+++ b/test/lib/rules/no-use-outside.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var rule = require('../../../lib/rules/no-use-outside');
+var Messages = require('../../../lib/messages');
+var RuleTester = require('eslint').RuleTester;
+
+require('babel-eslint');
+
+RuleTester.setDefaultConfig({
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  }
+});
+
+
+var ruleTester = new RuleTester();
+ruleTester.run('no-use-outside', rule, {
+
+  valid: [
+    'this._foo()',
+    'this._foo = 1',
+    'var foo = this._bar'
+  ],
+
+  invalid: [
+    {
+      code: `
+        foo._bar();
+      `,
+      errors: [{
+        message: Messages.get(Messages.NO_USE, '_bar'),
+        type: 'Identifier'
+      }]
+    },
+
+    {
+      code: `
+        foo._bar;
+      `,
+      errors: [{
+        message: Messages.get(Messages.NO_USE, '_bar'),
+        type: 'Identifier'
+      }]
+    },
+
+    {
+      code: `
+        baz = foo._bar;
+      `,
+      errors: [{
+        message: Messages.get(Messages.NO_USE, '_bar'),
+        type: 'Identifier'
+      }]
+    }
+  ]
+});


### PR DESCRIPTION
…own object

Rename `all` rule to `no-unused-or-undeclared`
